### PR TITLE
feat: layout 그룹단위로 분리

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import Header from "@/components/layout/Header";
+import Footer from "@/components/layout/Footer";
+
+export default function PublicLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home</div>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,0 @@
-export default function Home() {
-  return <div>Home</div>;
-}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,53 @@
+import Image from "next/image";
+import Link from "next/link";
+
+const SNS_LINKS = [
+  {
+    href: "https://www.facebook.com/",
+    src: "/icons/facebook.svg",
+    alt: "Facebook",
+  },
+  {
+    href: "https://www.instagram.com/",
+    src: "/icons/instagram.svg",
+    alt: "Instagram",
+  },
+  {
+    href: "https://www.youtube.com/",
+    src: "/icons/youtube.svg",
+    alt: "YouTube",
+  },
+  { href: "https://x.com/", src: "/icons/X.svg", alt: "X" },
+];
+
+export default function Footer() {
+  return (
+    <footer className="fixed bottom-0 left-0 w-full border-t border-gray-200 bg-white z-50">
+      <div className="mx-auto flex flex-col gap-3 px-6 py-5 h-[116px] md:h-[140px] md:flex-row md:items-center md:justify-between md:px-20 xl:px-50 md:gap-0">
+        <div className="flex items-center justify-center gap-6 text-md text-gray-600 font-medium  md:order-2">
+          <Link href="#" className="hover:underline">
+            Privacy Policy
+          </Link>
+          <span>•</span>
+          <Link href="#" className="hover:underline">
+            FAQ
+          </Link>
+        </div>
+
+        <div className="flex items-center justify-between md:contents">
+          <span className="text-md text-gray-400 font-medium md:order-1">
+            ©codeit - 2023
+          </span>
+
+          <div className="flex items-center gap-4 md:order-3">
+            {SNS_LINKS.map(({ href, src, alt }) => (
+              <a key={alt} href={href}>
+                <Image src={src} alt={alt} width={24} height={24} />
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/commons/utils/cn";
+
+import Link from "next/link";
+
+interface HeaderProps {
+  className?: string;
+}
+
+export default function Header({ className }: HeaderProps) {
+  return (
+    <header className={cn("px-5 py-5", className)}>
+      <div className="max-w-385 mx-auto h-10 flex items-center justify-between">
+        <Link href="/">로고</Link>
+        <Link href="/login">로그인</Link>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- layout rouer group 적용

## 🗨️ 논의 사항 (참고 사항)

- Header 띄우는 방식을 어떤식으로 하면좋을까요? 의견 부탁드립니다!
  1. sticky 적용으로 항상 따라오도록 하기
  2. 항상 맨 위에 고정시키기  

## 영향 범위

- 준석님꼐서 작업해주신 Footer 컴포넌트를 공통 레이아웃의 Footer 컴포넌트로 잠시 옮겼습니다.
- 그룹단위 레이아웃을 적용하기 위하여 일부 디렉토리를 옮겨야 합니다.

## 추가사항

* Auth 부분도 같은 방식으로 공통 레이아웃 작업가능할거같아요!

## 참고자료

* [라우터 그룹](https://nextjs-ko.org/docs/app/building-your-application/routing/route-groups)

이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.
(예: Closes #43 )
