### PR TITLE
feat: activities-preview

### DIFF
--- a/src/app/(public)/(main)/_components/AllActivitiesPreviewSection.tsx
+++ b/src/app/(public)/(main)/_components/AllActivitiesPreviewSection.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/Buttons/Button";
+import type { ActivityListItem } from "@/types/activities";
+import ActivityCard from "./ActivityCard";
+
+interface AllActivitiesPreviewSectionProps {
+  activities: ActivityListItem[];
+}
+
+export default function AllActivitiesPreviewSection({
+  activities,
+}: AllActivitiesPreviewSectionProps) {
+  if (activities.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="w-full">
+      <div className="mb-6 flex items-center justify-between sm:mb-8">
+        <h2 className="text-xl font-bold text-gray-900 sm:text-2xl">
+          🎡 모든 체험
+        </h2>
+        <Button
+          asChild
+          variant="secondary"
+          size="sm"
+          className="w-auto px-4 text-sm"
+        >
+          <Link href="/activities">전체보기</Link>
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-x-6 gap-y-8 md:grid-cols-2 lg:grid-cols-4">
+        {activities.map((activity) => (
+          <ActivityCard
+            key={activity.id}
+            data={{
+              id: activity.id,
+              image: activity.bannerImageUrl,
+              rating: activity.rating,
+              reviewCount: activity.reviewCount,
+              title: activity.title,
+              price: activity.price,
+            }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(public)/(main)/page.tsx
+++ b/src/app/(public)/(main)/page.tsx
@@ -2,38 +2,48 @@ import { randomInt } from "node:crypto";
 import { getActivityList } from "@/apis/activities.api";
 import HeroSection from "./_components/HeroSection";
 import BestItemsCarousel from "./_components/BestItemsCarousel";
+import AllActivitiesPreviewSection from "./_components/AllActivitiesPreviewSection";
 
 export default async function Home() {
-  const bestResponse = await getActivityList(
-    {
-      method: "offset",
-      sort: "most_reviewed",
-      size: 13,
-    },
-    {
-      revalidate: 3600,
-      tags: ["best-activities"],
-    },
-  );
+  const [bestResponse, latestResponse] = await Promise.all([
+    getActivityList(
+      {
+        method: "offset",
+        sort: "most_reviewed",
+        size: 13,
+      },
+      {
+        revalidate: 3600,
+        tags: ["best-activities"],
+      },
+    ),
+    getActivityList(
+      {
+        method: "offset",
+        sort: "latest",
+        size: 8,
+      },
+      {
+        revalidate: 3600,
+        tags: ["latest-activities"],
+      },
+    ),
+  ]);
 
   const topActivities = bestResponse.activities;
   const heroIndex = randomInt(topActivities.length || 1);
   const bestActivity = topActivities[heroIndex];
-
   const carouselActivities = topActivities.filter(
     (activity) => activity.id !== bestActivity?.id,
   );
+  const previewActivities = latestResponse.activities;
 
   return (
     <main className="hero-section pb-20">
       <div className="mx-auto flex max-w-[1200px] flex-col gap-10 px-6 pt-4 sm:gap-16 sm:pt-6">
-        <section>
-          <HeroSection bestActivity={bestActivity} />
-        </section>
-
-        <section>
-          <BestItemsCarousel activities={carouselActivities} />
-        </section>
+        <HeroSection bestActivity={bestActivity} />
+        <BestItemsCarousel activities={carouselActivities} />
+        <AllActivitiesPreviewSection activities={previewActivities} />
       </div>
     </main>
   );


### PR DESCRIPTION
## ✏️ 작업 내용

- 메인페이지 전체 체험 프리뷰 8개 배치
- 전체보기 버튼을 배치하여, 별도 리스트 페이지로 이동할 수 있도록 버튼 배치

## 🗨️ 논의 사항 (참고 사항)

- 메인페이지에서 쿼리스트링 기반 상태관리보다, 별도 페이지에서 관리하는 방향이 더 깔끔할것같아서 별도 리스트 페이지로 분리할 예정입니다.
- 별도 리스트 페이지는 디자인이 없어서 일반 커뮤니티 사이트나, SNS를 참고하여 작업할 예정입니다.

## 스크린샷

<img width="1175" height="941" alt="image" src="https://github.com/user-attachments/assets/e001c1d3-3ff3-49ae-8da3-0b2f294d9511" />


이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.
(예: Closes #116 )
