### PR TITLE
fix: 마이페이지 사이드메뉴 뱃지 쿼리 충돌 해결

### DIFF
--- a/src/app/mypage/_libs/useUserBadge.ts
+++ b/src/app/mypage/_libs/useUserBadge.ts
@@ -7,16 +7,14 @@ export function useUserBadge() {
   const results = useQueries({
     queries: [
       {
-        queryKey: ["myActivities"],
+        queryKey: ["myActivities", "badge"],
         queryFn: () => getMyActivityList({ cursorId: null }),
-        staleTime: Infinity,
-        gcTime: 1000 * 60 * 5,
+        staleTime: 0,
       },
       {
-        queryKey: ["myReservations"],
+        queryKey: ["myReservations", "badge"],
         queryFn: () => getMyReservationList({ cursorId: null }),
-        staleTime: Infinity,
-        gcTime: 1000 * 60 * 5,
+        staleTime: 0,
       },
     ],
   });


### PR DESCRIPTION
## ✏️ 작업 내용
- 데이터 구조(객체 vs 배열) 차이로 인해 발생하던 Cannot read properties of undefined (reading 'length') 에러 발견
- useUserBadge에서 사용하는 쿼리키를 ["myActivities", "badge"]로 분리하여 기존 useInfiniteQuery 데이터 구조와 겹치는 현상 해결

## 🗨️ 논의 사항 (참고 사항)
- 다른 페이지에 영향을 끼쳐 죄송합니다 ㅠㅠ 빠르게 수정하였으니 바로 머지될 수 있도록 확인 요청드립니다! 
- 키 뒤에 'badge'를 붙여 분리했지만, 상위 키인 ["myActivities"]를 무효화하면 뱃지 쿼리도 함께 갱신되도록 수정하였습니다.

이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.
(예: Closes #158)
