### PR TITLE
style: 전역 레이아웃 및 페이지별 일관된 패딩 적용

### DIFF
--- a/src/app/(public)/activities/[id]/page.tsx
+++ b/src/app/(public)/activities/[id]/page.tsx
@@ -79,7 +79,7 @@ export default async function ActivityDetailPage({
   const { activity, queryClient } = data;
 
   return (
-    <div className="mt-6 md:mt-10 xl:mt-15 px-4 md:px-5 xl:px-0 xl:w-[1120px]  mx-auto grid grid-cols-1 xl:grid-rows-[400px] xl:grid-cols-[670px_410px] xl:gap-x-10">
+    <div className="max-w-[1200px] mx-auto px-6 mt-6 md:mt-10 xl:mt-15 grid grid-cols-1 xl:grid-rows-[400px] xl:grid-cols-[670px_410px] xl:gap-x-10 xl:justify-between">
       <div className="xl:col-start-1">
         <BannerImages
           mainImageUrl={activity.bannerImageUrl}

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -28,8 +28,8 @@ export default function MyPageRootLayout({
     <>
       <div className="flex flex-col w-full min-h-screen">
         <Header />
-        <div className="flex-1 w-full max-w-[1200px] mx-auto">
-          <div className="flex md:gap-[50px] mt-[30px] mb-[30px] xl:mt-[40px] xl:mb-[40px] px-[24px] md:px-[30px]">
+        <div className="flex-1 max-w-[1200px] w-full mx-auto px-6">
+          <div className="flex md:gap-[50px] mt-[30px] mb-[30px] xl:mt-[40px] xl:mb-[40px]">
             <SideMenu isRootMyPage={isRootMyPage} currentPath={pathname} />
 
             <div

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -22,8 +22,8 @@ const SNS_LINKS = [
 
 export default function Footer() {
   return (
-    <footer className=" w-full border-t border-gray-200 bg-white z-50">
-      <div className="mx-auto flex flex-col gap-3 px-6 py-3.5 h-[80px] md:h-[90px] md:flex-row md:items-center md:justify-between md:px-20 xl:px-50 md:gap-0">
+    <footer className="w-full border-t border-gray-200 bg-white z-50">
+      <div className="max-w-[1200px] mx-auto flex flex-col gap-3 px-6 py-3.5 h-[80px] md:h-[90px] md:flex-row md:items-center md:justify-between md:gap-0">
         <div className="flex items-center justify-center gap-6 text-sm text-gray-600 font-medium  md:order-2">
           <Link href="#" className="hover:underline">
             Privacy Policy

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,7 +19,7 @@ export default function Header({ className }: HeaderProps) {
         className,
       )}
     >
-      <div className="mx-auto flex h-[70px] items-center justify-between px-6 md:h-[80px] md:px-20 xl:px-50">
+      <div className="max-w-[1200px] mx-auto flex h-[70px] items-center justify-between px-6 md:h-[80px]">
         <Link href="/">
           <div className="md:hidden">
             <Image


### PR DESCRIPTION
## ✏️ 작업 내용
- 페이지별로 상이했던 헤더, 푸터 및 메인 콘텐츠의 여백과 너비 설정을 통일하여 시각적 불균형을 해소
- 메인 페이지를 기준으로 전역 레이아웃을 max-width: 1200px, px-6으로 맞추어, 페이지 전환 시에도 레이아웃이 흔들리지 않도록 수정

## 🗨️ 논의 사항 (참고 사항)
- 미세한 차이였으나 서비스의 전반적인 완성도와 사용자 경험(UX)을 위해 공통 레이아웃 규격을 정리하였습니다. 혹시 다른 페이지에서 레이아웃이 어색하게 깨지는 부분이 있다면 말씀해 주세요!

## 🖼️ 참고 디자인
| Before (수정 전) | After (수정 후) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/ee841a4b-7ee2-4aa9-80e0-de0aeb4fa58f" width="450" /> | <img src="https://github.com/user-attachments/assets/ebcaf214-fc0d-4b85-b72f-94c41b9e2864" width="450" /> |


이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.
(예: Closes #184)
