### PR TITLE
refactor: available-schedules 쿼리 에러 ErrorBoundary로 선언적 처리

### DIFF
--- a/src/app/(public)/activities/[id]/_components/ReservationCalendar/lib/useReservation.ts
+++ b/src/app/(public)/activities/[id]/_components/ReservationCalendar/lib/useReservation.ts
@@ -44,6 +44,7 @@ export function useReservation(
   const { data: availableSchedules = [] } = useQuery({
     queryKey: ["available-schedules", activityId, year, month],
     queryFn: () => getAvailableSchedule(activityId, year, month),
+    throwOnError: true,
     select: (data) => {
       const now = new Date();
       const todayStr = format(now, "yyyy-MM-dd");

--- a/src/app/(public)/activities/[id]/_components/ReservationErrorBoundary.tsx
+++ b/src/app/(public)/activities/[id]/_components/ReservationErrorBoundary.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+import ErrorBoundary from "@/components/ErrorBoundary/ErrorBoundary";
+import QueryErrorFallback from "@/components/ErrorBoundary/QueryErrorFallback";
+
+interface ReservationErrorBoundaryProps {
+  children: ReactNode;
+}
+
+function ReservationErrorBoundary({
+  children,
+}: ReservationErrorBoundaryProps): ReactNode {
+  return (
+    <ErrorBoundary
+      fallback={(_, reset) => (
+        <QueryErrorFallback
+          reset={reset}
+          message="예약 가능 일정을 불러오는 데 실패했습니다."
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export { ReservationErrorBoundary };

--- a/src/app/(public)/activities/[id]/page.tsx
+++ b/src/app/(public)/activities/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@tanstack/react-query";
 import { UpwardPanel } from "./_components/UpwardPanel/UpwardPanel";
 import { notFound } from "next/navigation";
+import { ReservationErrorBoundary } from "./_components/ReservationErrorBoundary";
 
 export async function generateMetadata({
   params,
@@ -91,7 +92,9 @@ export default async function ActivityDetailPage({
         <ActivityHeader activity={activity} />
 
         <div className="hidden xl:block mt-8 w-full">
-          <ReservationCalendar activityId={activityId} price={activity.price} />
+          <ReservationErrorBoundary>
+            <ReservationCalendar activityId={activityId} price={activity.price} />
+          </ReservationErrorBoundary>
         </div>
       </div>
 
@@ -105,7 +108,9 @@ export default async function ActivityDetailPage({
         </HydrationBoundary>
       </div>
 
-      <UpwardPanel price={activity.price} activityId={activityId} />
+      <ReservationErrorBoundary>
+        <UpwardPanel price={activity.price} activityId={activityId} />
+      </ReservationErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `useReservation` 훅의 `useQuery`에 `throwOnError: true` 추가
  - 쿼리 실패 시 `[]` 폴백 대신 에러를 throw하여 ErrorBoundary가 잡을 수 있도록 변경
- `ReservationErrorBoundary` 클라이언트 컴포넌트 신규 추가
  - Server Component(`page.tsx`)에서 함수 prop을 Client Component로 직접 전달할 수 없는 Next.js 제약으로 인해 별도 파일로 분리
- `page.tsx`에서 `ReservationCalendar`(데스크톱)와 `UpwardPanel`(모바일) 각각 `ReservationErrorBoundary`로 감싸기
  - 두 컴포넌트는 CSS(`hidden xl:block` / `xl:hidden`)로 상호 배타적으로 렌더되므로 독립적인 에러 경계 적용

## 🗨️ 논의 사항 (참고 사항)

Closes #189