### PR TITLE
feat: reservation-status 스케줄 관리 기능 구현 및 임시 UI 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "global-nomad",
       "version": "0.1.0",
       "dependencies": {
+        "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@tanstack/react-query": "^5.90.21",
@@ -472,6 +473,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -515,6 +525,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.3.0.tgz",
+      "integrity": "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@base-ui/utils": "0.2.6",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.4.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.6.tgz",
+      "integrity": "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@commitlint/cli": {
@@ -4256,7 +4319,7 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4266,7 +4329,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4276,7 +4339,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5863,7 +5926,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -10642,6 +10705,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -11589,6 +11658,12 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -11959,7 +12034,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12016,7 +12091,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "commitlint": "commitlint --edit"
   },
   "dependencies": {
+    "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tanstack/react-query": "^5.90.21",

--- a/src/apis/myActivities.api.ts
+++ b/src/apis/myActivities.api.ts
@@ -4,17 +4,25 @@ import {
   CreateActivityResponse,
   MessageResponse,
   MyActivitiesListType,
+  ReservationListBySchedule,
   ReservationDashboardItem,
+  ReservationMutationStatus,
+  ReservationStatusFilter,
+  ReservedScheduleItem,
   UpdateActivityRequest,
 } from "@/types/myActivities.type";
 
+export const MY_ACTIVITIES_PAGE_SIZE = 10;
+
 export const getActivityList = async ({
   cursorId,
+  size = MY_ACTIVITIES_PAGE_SIZE,
 }: {
   cursorId?: number | null;
+  size?: number;
 }) => {
   const res = await axios.get<MyActivitiesListType>("/my-activities", {
-    params: { cursorId, size: 5 },
+    params: { cursorId, size },
   });
   return res.data;
 };
@@ -25,7 +33,7 @@ export const deleteMyActivity = async (activityId: number): Promise<void> => {
 
 export const getMyActivityList = async ({
   cursorId,
-  size = 5,
+  size = MY_ACTIVITIES_PAGE_SIZE,
 }: {
   cursorId?: number | null;
   size?: number;
@@ -87,4 +95,59 @@ export const getReservationDashboard = async ({
     { params: { year, month } },
   );
   return res.data;
+};
+
+export const getReservedSchedule = async ({
+  activityId,
+  date,
+}: {
+  activityId: number;
+  date: string;
+}): Promise<ReservedScheduleItem[]> => {
+  const res = await axios.get<ReservedScheduleItem[]>(
+    `/my-activities/${activityId}/reserved-schedule`,
+    { params: { date } },
+  );
+  return res.data;
+};
+
+export const getReservationsBySchedule = async ({
+  activityId,
+  scheduleId,
+  status,
+  cursorId,
+  size = MY_ACTIVITIES_PAGE_SIZE,
+}: {
+  activityId: number;
+  scheduleId: number;
+  status: ReservationStatusFilter;
+  cursorId?: number | null;
+  size?: number;
+}): Promise<ReservationListBySchedule> => {
+  const res = await axios.get<ReservationListBySchedule>(
+    `/my-activities/${activityId}/reservations`,
+    {
+      params: {
+        scheduleId,
+        status,
+        cursorId,
+        size,
+      },
+    },
+  );
+  return res.data;
+};
+
+export const updateReservationStatus = async ({
+  activityId,
+  reservationId,
+  status,
+}: {
+  activityId: number;
+  reservationId: number;
+  status: ReservationMutationStatus;
+}): Promise<void> => {
+  await axios.patch(`/my-activities/${activityId}/reservations/${reservationId}`, {
+    status,
+  });
 };

--- a/src/app/mypage/reservation-status/_components/ActivityDropdown.tsx
+++ b/src/app/mypage/reservation-status/_components/ActivityDropdown.tsx
@@ -1,31 +1,29 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Combobox as ComboboxPrimitive } from "@base-ui/react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { ChevronDownIcon } from "lucide-react";
 import { getActivityList } from "@/apis/myActivities.api";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/Dropdown/DropdownMenu";
+import { cn } from "@/commons/utils/cn";
 import useInfiniteScroll from "@/commons/hooks/useInfiniteScroll";
 import { Activity } from "@/types/myActivities.type";
+import ActivityDropdownMenu from "./ActivityDropdownMenu";
 
 interface ActivityDropdownProps {
   selectedActivity: Activity | null;
   onSelect: (activity: Activity) => void;
 }
 
-const PLACEHOLDER = "체험을 불러오는중...";
+const PLACEHOLDER = "Select an activity";
+const SEARCH_VISIBLE_THRESHOLD = 10;
 
 export default function ActivityDropdown({
   selectedActivity,
   onSelect,
 }: ActivityDropdownProps) {
   const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
     null,
   );
@@ -38,15 +36,35 @@ export default function ActivityDropdown({
       getNextPageParam: (lastPage) => lastPage.cursorId ?? undefined,
       staleTime: 60 * 1000,
     });
+  const isSearching = searchValue.trim().length > 0;
 
   const sentinelRef = useInfiniteScroll({
     onIntersect: fetchNextPage,
-    enabled: hasNextPage ?? false,
+    enabled: (hasNextPage ?? false) && !isSearching,
     loading: isFetchingNextPage,
     root: scrollContainer,
   });
 
-  const allActivities = data?.pages.flatMap((page) => page.activities) ?? [];
+  const allActivities = useMemo(
+    () => data?.pages.flatMap((page) => page.activities) ?? [],
+    [data],
+  );
+  const totalActivityCount = data?.pages[0]?.totalCount ?? allActivities.length;
+  const shouldShowSearch = totalActivityCount >= SEARCH_VISIBLE_THRESHOLD;
+  const hasAnyActivity = allActivities.length > 0;
+  const showFetchMoreIndicator = isFetchingNextPage && !isSearching;
+  const showInfiniteSentinel = !isSearching && !!hasNextPage;
+  const filteredActivities = useMemo(() => {
+    const normalizedQuery = searchValue.trim().toLowerCase();
+
+    if (!shouldShowSearch || !normalizedQuery) {
+      return allActivities;
+    }
+
+    return allActivities.filter((activity) =>
+      activity.title.toLowerCase().includes(normalizedQuery),
+    );
+  }, [allActivities, searchValue, shouldShowSearch]);
 
   useEffect(() => {
     const first = data?.pages[0]?.activities[0];
@@ -55,70 +73,74 @@ export default function ActivityDropdown({
     }
   }, [data, selectedActivity, onSelect]);
 
-  const handleValueChange = (val: string) => {
-    const activity = allActivities.find((a) => a.id === Number(val));
-    if (activity) {
-      onSelect(activity);
-      setOpen(false);
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    setSearchValue("");
+  };
+
+  const handleValueChange = (activity: Activity | null) => {
+    if (!activity) {
+      return;
     }
+
+    onSelect(activity);
+    setSearchValue("");
+    setOpen(false);
   };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <button
-          className="flex w-full items-center justify-between rounded-2xl border border-gray-300 bg-white px-[16px] py-[14px] text-[16px] font-medium outline-none data-[state=open]:border-[#1F1F22]"
-          aria-label="체험 선택"
+    <ComboboxPrimitive.Root<Activity>
+      items={filteredActivities}
+      value={selectedActivity}
+      open={open}
+      inputValue={searchValue}
+      itemToStringLabel={(activity) => activity.title}
+      isItemEqualToValue={(item, value) => item.id === value.id}
+      onOpenChange={handleOpenChange}
+      onInputValueChange={setSearchValue}
+      onValueChange={handleValueChange}
+    >
+      <ComboboxPrimitive.Trigger
+        className={cn(
+          "flex w-full items-center justify-between rounded-2xl border bg-white px-[16px] py-[14px] text-[16px] font-medium tracking-[-2.5%] outline-none transition-colors",
+          open ? "border-[#1F1F22]" : "border-gray-300",
+        )}
+        aria-label="Select activity"
+      >
+        <span
+          className={selectedActivity ? "text-[#1F1F22]" : "text-[#A4A1AA]"}
         >
-          <span
-            className={selectedActivity ? "text-[#1F1F22]" : "text-[#A4A1AA]"}
-          >
-            {selectedActivity?.title ?? PLACEHOLDER}
-          </span>
-          <ChevronDownIcon
-            className="size-5 shrink-0 text-[#1F1F22] transition-transform duration-200 data-[state=open]:rotate-180"
-            data-state={open ? "open" : "closed"}
+          {selectedActivity?.title ?? PLACEHOLDER}
+        </span>
+        <ChevronDownIcon
+          className={cn(
+            "size-5 shrink-0 text-[#1F1F22] transition-transform duration-200",
+            open && "rotate-180",
+          )}
+        />
+      </ComboboxPrimitive.Trigger>
+
+      <ComboboxPrimitive.Portal>
+        <ComboboxPrimitive.Positioner
+          side="bottom"
+          sideOffset={6}
+          align="start"
+          className="z-50"
+        >
+          <ActivityDropdownMenu
+            items={filteredActivities}
+            hasAnyActivity={hasAnyActivity}
+            isLoading={isLoading}
+            searchValue={searchValue}
+            showFetchMoreIndicator={showFetchMoreIndicator}
+            showInfiniteSentinel={showInfiniteSentinel}
+            sentinelRef={sentinelRef}
+            onScrollContainerChange={setScrollContainer}
+            onSearchValueChange={setSearchValue}
+            shouldShowSearch={shouldShowSearch}
           />
-        </button>
-      </DropdownMenuTrigger>
-
-      <DropdownMenuContent className="border border-gray-200 bg-white shadow-[0_4px_16px_rgba(0,0,0,0.08)] ">
-        <div ref={setScrollContainer} className="max-h-[300px] overflow-y-auto">
-          {isLoading && (
-            <div className="py-4 text-center text-sm text-[#A4A1AA]">
-              불러오는 중...
-            </div>
-          )}
-
-          {!isLoading && allActivities.length === 0 && (
-            <div className="py-4 text-center text-sm text-[#A4A1AA]">
-              등록된 체험이 없습니다.
-            </div>
-          )}
-
-          <DropdownMenuRadioGroup
-            value={selectedActivity ? String(selectedActivity.id) : ""}
-            onValueChange={handleValueChange}
-          >
-            {allActivities.map((activity) => (
-              <DropdownMenuRadioItem
-                key={activity.id}
-                value={String(activity.id)}
-              >
-                {activity.title}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-
-          {isFetchingNextPage && (
-            <div className="py-2 text-center text-sm text-[#A4A1AA]">
-              불러오는 중...
-            </div>
-          )}
-
-          <div ref={sentinelRef} className="h-1" />
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </ComboboxPrimitive.Positioner>
+      </ComboboxPrimitive.Portal>
+    </ComboboxPrimitive.Root>
   );
 }

--- a/src/app/mypage/reservation-status/_components/ActivityDropdownMenu.tsx
+++ b/src/app/mypage/reservation-status/_components/ActivityDropdownMenu.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Combobox as ComboboxPrimitive } from "@base-ui/react";
+import { CheckIcon, SearchIcon } from "lucide-react";
+import type { RefObject } from "react";
+import type { Activity } from "@/types/myActivities.type";
+
+interface ActivityDropdownMenuProps {
+  items: Activity[];
+  hasAnyActivity: boolean;
+  isLoading: boolean;
+  searchValue: string;
+  showFetchMoreIndicator: boolean;
+  showInfiniteSentinel: boolean;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  onScrollContainerChange: (node: HTMLDivElement | null) => void;
+  onSearchValueChange: (value: string) => void;
+  shouldShowSearch: boolean;
+}
+
+const SEARCH_PLACEHOLDER = "Search activities";
+const LOADING_TEXT = "Loading activities...";
+const EMPTY_TEXT = "No activities found.";
+const NO_SEARCH_RESULT_TEXT = "No matching activities.";
+
+export default function ActivityDropdownMenu({
+  items,
+  hasAnyActivity,
+  isLoading,
+  searchValue,
+  showFetchMoreIndicator,
+  showInfiniteSentinel,
+  sentinelRef,
+  onScrollContainerChange,
+  onSearchValueChange,
+  shouldShowSearch,
+}: ActivityDropdownMenuProps) {
+  return (
+    <ComboboxPrimitive.Popup className="group/combobox-popup w-(--anchor-width) overflow-hidden rounded-lg border border-gray-200 bg-white shadow-[0_4px_16px_rgba(0,0,0,0.08)]">
+      {shouldShowSearch && (
+        <div className="border-b border-gray-100 p-2">
+          <div className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2">
+            <SearchIcon className="size-4 shrink-0 text-[#A4A1AA]" />
+            <input
+              value={searchValue}
+              onChange={(e) => onSearchValueChange(e.target.value)}
+              placeholder={SEARCH_PLACEHOLDER}
+              className="w-full border-0 bg-transparent p-0 text-[14px] font-medium tracking-[-2.5%] text-[#1F1F22] outline-none placeholder:text-[#A4A1AA]"
+              autoFocus
+            />
+          </div>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="py-4 text-center text-sm text-[#A4A1AA]">
+          {LOADING_TEXT}
+        </div>
+      ) : (
+        <ComboboxPrimitive.List
+          ref={onScrollContainerChange}
+          className="max-h-[300px] overflow-y-auto p-2"
+        >
+          {items.map((activity) => (
+            <ComboboxPrimitive.Item
+              key={activity.id}
+              value={activity}
+              className="relative flex cursor-pointer items-center gap-1.5 rounded-md py-2 pr-8 pl-1.5 text-[16px] font-medium tracking-[-2.5%] text-[#1F1F22] outline-none select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[selected]:text-[#3D9EF2]"
+            >
+              {activity.title}
+              <ComboboxPrimitive.ItemIndicator>
+                <span className="absolute right-2 flex items-center justify-center">
+                  <CheckIcon className="size-4" />
+                </span>
+              </ComboboxPrimitive.ItemIndicator>
+            </ComboboxPrimitive.Item>
+          ))}
+
+          <ComboboxPrimitive.Empty className="hidden py-4 text-center text-sm text-[#A4A1AA] group-data-empty/combobox-popup:block">
+            {hasAnyActivity ? NO_SEARCH_RESULT_TEXT : EMPTY_TEXT}
+          </ComboboxPrimitive.Empty>
+
+          {showFetchMoreIndicator && (
+            <div className="py-2 text-center text-sm text-[#A4A1AA]">
+              {LOADING_TEXT}
+            </div>
+          )}
+
+          {showInfiniteSentinel && (
+            <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+          )}
+        </ComboboxPrimitive.List>
+      )}
+    </ComboboxPrimitive.Popup>
+  );
+}

--- a/src/app/mypage/reservation-status/_components/ReservationCalendar.tsx
+++ b/src/app/mypage/reservation-status/_components/ReservationCalendar.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { DayPicker, type DayButtonProps } from "react-day-picker";
 import { ko } from "date-fns/locale";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { getReservationDashboard } from "@/apis/myActivities.api";
-import type { ReservationCounts } from "@/types/myActivities.type";
 import { ReservationDayButton } from "./ReservationDayButton";
+import ReservationListPanel from "./ReservationListPanel";
+import ReservationSchedulePanel from "./ReservationSchedulePanel";
+import { useReservationCalendarState } from "../_libs/useReservationCalendarState";
 
 interface ReservationCalendarProps {
   activityId: number | undefined;
@@ -16,40 +15,34 @@ interface ReservationCalendarProps {
 export default function ReservationCalendar({
   activityId,
 }: ReservationCalendarProps) {
-  const [currentMonth, setCurrentMonth] = useState<Date>(
-    () => new Date(new Date().getFullYear(), new Date().getMonth(), 1),
-  );
-
-  const year = currentMonth.getFullYear().toString();
-  const month = (currentMonth.getMonth() + 1).toString().padStart(2, "0");
-
-  const { data: dashboardData = [] } = useQuery({
-    queryKey: ["reservationDashboard", activityId, year, month],
-    queryFn: () =>
-      getReservationDashboard({ activityId: activityId!, year, month }),
-    enabled: !!activityId,
-    staleTime: 60 * 1000,
-  });
-
-  const reservationMap = useMemo<Record<string, ReservationCounts>>(
-    () =>
-      Object.fromEntries(
-        dashboardData.map((item) => [item.date, item.reservations]),
-      ),
-    [dashboardData],
-  );
+  const {
+    currentMonth,
+    reservationMap,
+    reservations,
+    schedules,
+    selectedDate,
+    selectedScheduleId,
+    selectedStatus,
+    statusLabels,
+    isMutating,
+    onDateSelect,
+    onMonthChange,
+    onReservationAction,
+    onScheduleSelect,
+    onStatusSelect,
+  } = useReservationCalendarState(activityId);
 
   const DayButton = (props: DayButtonProps) => (
     <ReservationDayButton {...props} reservationMap={reservationMap} />
   );
 
   return (
-    <div className="mt-[16px] md:rounded-3xl md:p-4 w-full md:shadow-[0_4px_16px_rgba(0,0,0,0.08)]">
+    <div className="mt-[16px] w-full md:rounded-3xl md:p-4 md:shadow-[0_4px_16px_rgba(0,0,0,0.08)]">
       <DayPicker
         mode="single"
         month={currentMonth}
-        onMonthChange={setCurrentMonth}
-        onSelect={(date) => alert(date?.toLocaleDateString("ko-KR"))}
+        onMonthChange={onMonthChange}
+        onSelect={onDateSelect}
         showOutsideDays
         locale={ko}
         formatters={{
@@ -59,19 +52,19 @@ export default function ReservationCalendar({
             ["S", "M", "T", "W", "T", "F", "S"][day.getDay()],
         }}
         classNames={{
-          months: "relative flex flex-col w-full",
+          months: "relative flex w-full flex-col",
           month: "flex w-full flex-col gap-4",
-          month_caption: "flex items-center justify-center h-8",
-          caption_label: "font-semibold text-md",
-          nav: "absolute inset-x-0 top-0 h-8 flex items-center justify-center",
-          button_previous: "pr-15 rounded hover:bg-gray-100 text-gray-700",
-          button_next: "pl-15 rounded hover:bg-gray-100 text-gray-700",
+          month_caption: "flex h-8 items-center justify-center",
+          caption_label: "text-md font-semibold",
+          nav: "absolute inset-x-0 top-0 flex h-8 items-center justify-center",
+          button_previous: "rounded pr-15 text-gray-700 hover:text-[#3D9EF2]",
+          button_next: "rounded pl-15 text-gray-700 hover:text-[#3D9EF2]",
           weekdays: "flex w-full border-b border-gray-300 pb-3",
           weekday:
-            "flex-1 text-center text-[0.8rem] text-muted-foreground select-none ",
+            "flex-1 select-none text-center text-[0.8rem] text-muted-foreground",
           weeks: "w-full",
-          week: "flex w-full mt-2",
-          day: "aspect-auto h-[90px] md:h-[110px] flex-1",
+          week: "mt-2 flex w-full",
+          day: "aspect-auto h-[90px] flex-1 md:h-[110px]",
         }}
         components={{
           Chevron: ({ orientation }) =>
@@ -82,6 +75,23 @@ export default function ReservationCalendar({
             ),
           DayButton,
         }}
+      />
+
+      <ReservationSchedulePanel
+        selectedDate={selectedDate}
+        schedules={schedules}
+        selectedScheduleId={selectedScheduleId}
+        selectedStatus={selectedStatus}
+        onScheduleSelect={onScheduleSelect}
+        onStatusSelect={onStatusSelect}
+      />
+
+      <ReservationListPanel
+        isMutating={isMutating}
+        reservations={reservations}
+        selectedStatus={selectedStatus}
+        statusLabels={statusLabels}
+        onReservationAction={onReservationAction}
       />
     </div>
   );

--- a/src/app/mypage/reservation-status/_components/ReservationListPanel.tsx
+++ b/src/app/mypage/reservation-status/_components/ReservationListPanel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Button } from "@/components/ui/Buttons/Button";
+import type {
+  ReservationMutationStatus,
+  ReservationStatusFilter,
+  ReservationWithUserItem,
+} from "@/types/myActivities.type";
+
+interface ReservationListPanelProps {
+  isMutating: boolean;
+  reservations: ReservationWithUserItem[];
+  selectedStatus: ReservationStatusFilter | null;
+  statusLabels: Record<ReservationStatusFilter, string>;
+  onReservationAction: (
+    reservationId: number,
+    status: ReservationMutationStatus,
+  ) => void;
+}
+
+export default function ReservationListPanel({
+  isMutating,
+  reservations,
+  selectedStatus,
+  statusLabels,
+  onReservationAction,
+}: ReservationListPanelProps) {
+  if (!selectedStatus) {
+    return null;
+  }
+
+  return (
+    <div className="mt-6 rounded-2xl border border-gray-200 bg-white p-4 shadow-[0_4px_16px_rgba(0,0,0,0.08)]">
+      <div className="text-sm font-semibold text-[#1F1F22]">
+        {statusLabels[selectedStatus]} 예약 목록
+      </div>
+
+      {reservations.length === 0 ? (
+        <p className="mt-3 text-sm text-[#84858C]">
+          선택한 상태의 예약 내역이 없어요.
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-3">
+          {reservations.map((reservation) => (
+            <li
+              key={reservation.id}
+              className="rounded-xl border border-gray-100 bg-[#FAFAFA] px-4 py-3"
+            >
+              <div>
+                <div className="text-sm font-medium text-[#1F1F22]">
+                  {reservation.nickname}
+                </div>
+                <div className="mt-1 text-sm text-[#84858C]">
+                  인원 {reservation.headCount}명 / 금액{" "}
+                  {reservation.totalPrice.toLocaleString()}원
+                </div>
+              </div>
+
+              {selectedStatus === "pending" && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="default"
+                    disabled={isMutating}
+                    onClick={() =>
+                      onReservationAction(reservation.id, "confirmed")
+                    }
+                  >
+                    승인하기
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={isMutating}
+                    onClick={() =>
+                      onReservationAction(reservation.id, "declined")
+                    }
+                  >
+                    거절하기
+                  </Button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/mypage/reservation-status/_components/ReservationSchedulePanel.tsx
+++ b/src/app/mypage/reservation-status/_components/ReservationSchedulePanel.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { cn } from "@/commons/utils/cn";
+import type {
+  ReservationStatusFilter,
+  ReservedScheduleItem,
+} from "@/types/myActivities.type";
+
+interface ReservationSchedulePanelProps {
+  selectedDate: string | null;
+  schedules: ReservedScheduleItem[];
+  selectedScheduleId: number | null;
+  selectedStatus: ReservationStatusFilter | null;
+  onScheduleSelect: (scheduleId: number) => void;
+  onStatusSelect: (status: ReservationStatusFilter) => void;
+}
+
+const STATUS_LABELS: Record<ReservationStatusFilter, string> = {
+  pending: "신청",
+  confirmed: "승인",
+  declined: "거절",
+};
+
+export default function ReservationSchedulePanel({
+  selectedDate,
+  schedules,
+  selectedScheduleId,
+  selectedStatus,
+  onScheduleSelect,
+  onStatusSelect,
+}: ReservationSchedulePanelProps) {
+  if (!selectedDate) {
+    return null;
+  }
+
+  const selectedSchedule =
+    schedules.find((schedule) => schedule.scheduleId === selectedScheduleId) ??
+    null;
+
+  return (
+    <div className="mt-6 rounded-2xl border border-gray-200 bg-white p-4 shadow-[0_4px_16px_rgba(0,0,0,0.08)]">
+      <div className="text-sm font-semibold text-[#1F1F22]">
+        {selectedDate} 스케줄
+      </div>
+
+      {schedules.length === 0 ? (
+        <p className="mt-3 text-sm text-[#84858C]">
+          선택한 날짜에 조회 가능한 예약 스케줄이 없어요.
+        </p>
+      ) : (
+        <>
+          <ul className="mt-3 space-y-3">
+            {schedules.map((schedule) => {
+              const isSelected = schedule.scheduleId === selectedScheduleId;
+
+              return (
+                <li key={schedule.scheduleId}>
+                  <button
+                    type="button"
+                    onClick={() => onScheduleSelect(schedule.scheduleId)}
+                    className={cn(
+                      "w-full rounded-xl border px-4 py-3 text-left transition-colors",
+                      isSelected
+                        ? "border-[#3D9EF2] bg-[#F4FAFF]"
+                        : "border-gray-100 bg-[#FAFAFA]",
+                    )}
+                  >
+                    <div className="text-sm font-medium text-[#1F1F22]">
+                      {schedule.startTime} - {schedule.endTime}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {(
+              [
+                "pending",
+                "confirmed",
+                "declined",
+              ] as ReservationStatusFilter[]
+            ).map((status) => {
+              const isSelected = selectedStatus === status;
+              const count = selectedSchedule?.count[status] ?? 0;
+
+              return (
+                <button
+                  key={status}
+                  type="button"
+                  onClick={() => onStatusSelect(status)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-sm font-medium transition-colors",
+                    isSelected &&
+                      status === "pending" &&
+                      "border-[#D7E9F9] bg-[#E5F3FF] text-[#3D9EF2]",
+                    isSelected &&
+                      status === "confirmed" &&
+                      "border-[#FFE8A3] bg-[#FFF7DB] text-[#D39A00]",
+                    isSelected &&
+                      status === "declined" &&
+                      "border-[#F3D2D2] bg-[#FFF1F1] text-[#D14B4B]",
+                    !isSelected && "border-gray-200 bg-white text-[#84858C]",
+                  )}
+                >
+                  {STATUS_LABELS[status]} {count}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/mypage/reservation-status/_components/ReservationStatusContent.tsx
+++ b/src/app/mypage/reservation-status/_components/ReservationStatusContent.tsx
@@ -4,11 +4,28 @@ import { useState } from "react";
 import { Activity } from "@/types/myActivities.type";
 import ActivityDropdown from "./ActivityDropdown";
 import ReservationCalendar from "./ReservationCalendar";
+import EmptyState from "@/components/ui/EmptyState/EmptyState";
 
-export default function ReservationStatusContent() {
+interface ReservationStatusContentProps {
+  hasActivities: boolean;
+  initialSelectedActivity?: Activity | null;
+}
+
+export default function ReservationStatusContent({
+  hasActivities,
+  initialSelectedActivity = null,
+}: ReservationStatusContentProps) {
   const [selectedActivity, setSelectedActivity] = useState<Activity | null>(
-    null,
+    initialSelectedActivity,
   );
+
+  if (!hasActivities) {
+    return (
+      <div className="flex flex-col items-center justify-center mt-[43px] min-h-[500px]">
+        <EmptyState message="아직 등록한 체험이 없어요" />
+      </div>
+    );
+  }
 
   return (
     <section className="mt-[24px] md:mt-[28px] xl:mt-[36px]">

--- a/src/app/mypage/reservation-status/_libs/useReservationCalendarState.ts
+++ b/src/app/mypage/reservation-status/_libs/useReservationCalendarState.ts
@@ -1,0 +1,327 @@
+"use client";
+
+import { useEffect, useMemo, useReducer } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  getReservationDashboard,
+  getReservationsBySchedule,
+  getReservedSchedule,
+  updateReservationStatus,
+} from "@/apis/myActivities.api";
+import type {
+  ReservationCounts,
+  ReservationMutationStatus,
+  ReservationStatusFilter,
+  ReservationWithUserItem,
+  ReservedScheduleItem,
+} from "@/types/myActivities.type";
+
+interface ReservationCalendarState {
+  currentMonth: Date;
+  selectedDate: string | null;
+  selectedSchedule: ReservedScheduleItem | null;
+  selectedStatus: ReservationStatusFilter | null;
+}
+
+type ReservationCalendarAction =
+  | { type: "monthChanged"; payload: Date }
+  | {
+      type: "dateSelected";
+      payload: {
+        date: string;
+      };
+    }
+  | {
+      type: "scheduleSelected";
+      payload: {
+        schedule: ReservedScheduleItem;
+      };
+    }
+  | {
+      type: "statusSelected";
+      payload: {
+        status: ReservationStatusFilter;
+      };
+    }
+  | { type: "resetSelection" };
+
+const STATUS_LABELS: Record<ReservationStatusFilter, string> = {
+  pending: "신청",
+  confirmed: "승인",
+  declined: "거절",
+};
+
+function createInitialState(): ReservationCalendarState {
+  return {
+    currentMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+    selectedDate: null,
+    selectedSchedule: null,
+    selectedStatus: null,
+  };
+}
+
+function reservationCalendarReducer(
+  state: ReservationCalendarState,
+  action: ReservationCalendarAction,
+): ReservationCalendarState {
+  switch (action.type) {
+    case "monthChanged":
+      return {
+        ...state,
+        currentMonth: action.payload,
+      };
+    case "dateSelected":
+      return {
+        ...state,
+        selectedDate: action.payload.date,
+        selectedSchedule: null,
+        selectedStatus: null,
+      };
+    case "scheduleSelected":
+      return {
+        ...state,
+        selectedSchedule: action.payload.schedule,
+        selectedStatus: "pending",
+      };
+    case "statusSelected":
+      return {
+        ...state,
+        selectedStatus: action.payload.status,
+      };
+    case "resetSelection":
+      return {
+        ...state,
+        selectedDate: null,
+        selectedSchedule: null,
+        selectedStatus: null,
+      };
+    default:
+      return state;
+  }
+}
+
+export function useReservationCalendarState(activityId: number | undefined) {
+  const queryClient = useQueryClient();
+  const [state, dispatch] = useReducer(
+    reservationCalendarReducer,
+    undefined,
+    createInitialState,
+  );
+
+  const year = state.currentMonth.getFullYear().toString();
+  const month = (state.currentMonth.getMonth() + 1).toString().padStart(2, "0");
+
+  const { data: dashboardData = [] } = useQuery({
+    queryKey: ["reservationDashboard", activityId, year, month],
+    queryFn: () =>
+      getReservationDashboard({ activityId: activityId!, year, month }),
+    enabled: !!activityId,
+    staleTime: 60 * 1000,
+  });
+
+  const reservationMap = useMemo<Record<string, ReservationCounts>>(
+    () =>
+      Object.fromEntries(
+        dashboardData.map((item) => [item.date, item.reservations]),
+      ),
+    [dashboardData],
+  );
+
+  const selectedDateCounts = state.selectedDate
+    ? reservationMap[state.selectedDate]
+    : undefined;
+  const hasReservationsOnSelectedDate = selectedDateCounts
+    ? Object.values(selectedDateCounts).some((count) => count > 0)
+    : false;
+
+  const { data: schedules = [] } = useQuery({
+    queryKey: ["reservedSchedule", activityId, state.selectedDate],
+    queryFn: () =>
+      getReservedSchedule({
+        activityId: activityId!,
+        date: state.selectedDate!,
+      }),
+    enabled:
+      !!activityId && !!state.selectedDate && hasReservationsOnSelectedDate,
+    staleTime: 60 * 1000,
+  });
+
+  const { data: reservationData } = useQuery({
+    queryKey: [
+      "reservationsBySchedule",
+      activityId,
+      state.selectedSchedule?.scheduleId,
+      state.selectedStatus,
+    ],
+    queryFn: () =>
+      getReservationsBySchedule({
+        activityId: activityId!,
+        scheduleId: state.selectedSchedule!.scheduleId,
+        status: state.selectedStatus!,
+      }),
+    enabled: !!activityId && !!state.selectedSchedule && !!state.selectedStatus,
+    staleTime: 60 * 1000,
+  });
+
+  const updateReservationMutation = useMutation({
+    mutationFn: ({
+      reservationId,
+      status,
+    }: {
+      reservationId: number;
+      status: ReservationMutationStatus;
+    }) =>
+      updateReservationStatus({
+        activityId: activityId!,
+        reservationId,
+        status,
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["reservationDashboard", activityId, year, month],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["reservedSchedule", activityId, state.selectedDate],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [
+            "reservationsBySchedule",
+            activityId,
+            state.selectedSchedule?.scheduleId,
+          ],
+        }),
+      ]);
+    },
+  });
+
+  useEffect(() => {
+    if (!state.selectedDate || !hasReservationsOnSelectedDate) {
+      return;
+    }
+
+    if (!schedules.length) {
+      return;
+    }
+
+    const currentScheduleStillExists = state.selectedSchedule
+      ? schedules.some(
+          (schedule) => schedule.scheduleId === state.selectedSchedule?.scheduleId,
+        )
+      : false;
+
+    if (!currentScheduleStillExists) {
+      dispatch({
+        type: "scheduleSelected",
+        payload: {
+          schedule: schedules[0],
+        },
+      });
+    }
+  }, [
+    hasReservationsOnSelectedDate,
+    schedules,
+    state.selectedDate,
+    state.selectedSchedule,
+  ]);
+
+  useEffect(() => {
+    if (!state.selectedSchedule || state.selectedStatus) {
+      return;
+    }
+
+    dispatch({
+      type: "statusSelected",
+      payload: {
+        status: "pending",
+      },
+    });
+  }, [state.selectedSchedule, state.selectedStatus]);
+
+  const reservations: ReservationWithUserItem[] =
+    reservationData?.reservations ?? [];
+
+  const handleDateSelect = (date: Date | undefined) => {
+    if (!activityId || !date) {
+      dispatch({ type: "resetSelection" });
+      return;
+    }
+
+    const formattedDate = [
+      date.getFullYear(),
+      String(date.getMonth() + 1).padStart(2, "0"),
+      String(date.getDate()).padStart(2, "0"),
+    ].join("-");
+
+    const counts = reservationMap[formattedDate];
+    const hasReservations = counts
+      ? Object.values(counts).some((count) => count > 0)
+      : false;
+
+    if (!hasReservations) {
+      dispatch({ type: "resetSelection" });
+      return;
+    }
+
+    dispatch({
+      type: "dateSelected",
+      payload: {
+        date: formattedDate,
+      },
+    });
+  };
+
+  const handleScheduleSelect = (scheduleId: number) => {
+    const schedule =
+      schedules.find((item) => item.scheduleId === scheduleId) ?? null;
+
+    if (!schedule) {
+      return;
+    }
+
+    dispatch({
+      type: "scheduleSelected",
+      payload: {
+        schedule,
+      },
+    });
+  };
+
+  const handleStatusSelect = (status: ReservationStatusFilter) => {
+    dispatch({
+      type: "statusSelected",
+      payload: {
+        status,
+      },
+    });
+  };
+
+  const handleReservationAction = (
+    reservationId: number,
+    status: ReservationMutationStatus,
+  ) => {
+    updateReservationMutation.mutate({ reservationId, status });
+  };
+
+  return {
+    currentMonth: state.currentMonth,
+    reservationMap,
+    reservations,
+    schedules,
+    selectedDate: state.selectedDate,
+    selectedScheduleId: state.selectedSchedule?.scheduleId ?? null,
+    selectedStatus: state.selectedStatus,
+    statusLabels: STATUS_LABELS,
+    isMutating: updateReservationMutation.isPending,
+    onDateSelect: handleDateSelect,
+    onMonthChange: (month: Date) =>
+      dispatch({ type: "monthChanged", payload: month }),
+    onReservationAction: handleReservationAction,
+    onScheduleSelect: handleScheduleSelect,
+    onStatusSelect: handleStatusSelect,
+  };
+}

--- a/src/app/mypage/reservation-status/page.tsx
+++ b/src/app/mypage/reservation-status/page.tsx
@@ -1,11 +1,61 @@
+import { cookies, headers } from "next/headers";
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 import ReservationStatusHeader from "./_components/ReservationStatusHeader";
 import ReservationStatusContent from "./_components/ReservationStatusContent";
+import { MyActivitiesListType } from "@/types/myActivities.type";
 
-export default function ReservationStatusPage() {
+export default async function ReservationStatusPage() {
+  const queryClient = new QueryClient();
+  const cookieStore = await cookies();
+  const headerStore = await headers();
+  const protocol = headerStore.get("x-forwarded-proto") ?? "http";
+  const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host");
+
+  if (!host) {
+    throw new Error("Failed to resolve request host for SSR prefetch.");
+  }
+
+  const origin = `${protocol}://${host}`;
+  const cookieHeader = cookieStore.toString();
+
+  const initialActivities = await queryClient.fetchInfiniteQuery({
+    queryKey: ["myActivities"] as const,
+    queryFn: async () => {
+      const response = await fetch(`${origin}/api/my-activities`, {
+        headers: {
+          ...(cookieHeader && { cookie: cookieHeader }),
+        },
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch myActivities");
+      }
+
+      return (await response.json()) as MyActivitiesListType;
+    },
+    initialPageParam: null as number | null,
+    getNextPageParam: (lastPage: MyActivitiesListType) =>
+      lastPage.cursorId ?? undefined,
+  });
+
+  const initialSelectedActivity =
+    initialActivities.pages[0]?.activities[0] ?? null;
+  const hasActivities = initialActivities.pages[0]?.activities.length > 0;
+
   return (
     <main className="md:px-0 md:py-0 xl:px-0 xl:py-0">
       <ReservationStatusHeader />
-      <ReservationStatusContent />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ReservationStatusContent
+          hasActivities={hasActivities}
+          initialSelectedActivity={initialSelectedActivity}
+        />
+      </HydrationBoundary>
     </main>
   );
 }

--- a/src/types/myActivities.type.ts
+++ b/src/types/myActivities.type.ts
@@ -111,3 +111,41 @@ export interface ReservationDashboardItem {
   date: string; // "YYYY-MM-DD"
   reservations: ReservationCounts;
 }
+
+export interface ReservedScheduleItem {
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+  count: {
+    pending: number;
+    confirmed: number;
+    declined: number;
+  };
+}
+
+export type ReservationStatusFilter = "pending" | "confirmed" | "declined";
+export type ReservationMutationStatus = "confirmed" | "declined";
+
+export interface ReservationWithUserItem {
+  id: number;
+  nickname: string;
+  userId: number;
+  teamId: string;
+  activityId: number;
+  scheduleId: number;
+  status: ReservationStatusFilter;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReservationListBySchedule {
+  reservations: ReservationWithUserItem[];
+  totalCount: number;
+  cursorId: number | null;
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- UI 는 임시로 간단하게 처리하고, API 연동을 우선 처리하였습니다.
- 축제목록 Dropdown을 CommboBox로 변경하고 등록한 축제가 10개 이상 (기본 size보다 큰 경우) 검색바가 노출되도록 추가하였습니다.

## 🗨️ 논의 사항 (참고 사항)

- 기존에 준석님께서 작업해주신 부분 중 페이지가 전부 CSR 위주로 동작하고있어서 초기 축제드롭다운은 프리패칭으로 옮겨서 초기로딩상태를 제거하였습니다.
- asdie 패널쪽이 상단에 고정되는거같은데 이 부분을 항상 따라 움직이도록 조정할지 의견 부탁드립니다.

이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.
(예: Closes #199)
