### PR TITLE
fix: 체험 삭제 시 Data Cache 무효화 및 메인페이지 리다이렉트 (#201)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4319,7 +4319,7 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4329,7 +4329,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4339,7 +4339,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5926,7 +5926,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -12034,7 +12034,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12091,7 +12091,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/src/actions/activities.action.ts
+++ b/src/actions/activities.action.ts
@@ -1,0 +1,12 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+import { ACTIVITY_CACHE_TAGS } from "@/commons/consts/cacheTags";
+
+const PURGE: { expire: number } = { expire: 0 };
+
+export async function revalidateActivityListCache(): Promise<void> {
+  revalidateTag(ACTIVITY_CACHE_TAGS.BEST, PURGE);
+  revalidateTag(ACTIVITY_CACHE_TAGS.LATEST, PURGE);
+  revalidateTag(ACTIVITY_CACHE_TAGS.LIST, PURGE);
+}

--- a/src/apis/activities.api.ts
+++ b/src/apis/activities.api.ts
@@ -6,6 +6,7 @@ import {
   AvailableSchedule,
 } from "@/types/activities";
 import { buildQueryString } from "@/commons/utils/buildQueryString";
+import { ACTIVITY_CACHE_TAGS } from "@/commons/consts/cacheTags";
 import axios from "./axios";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -16,7 +17,7 @@ export const getActivityList = async (
 ): Promise<ActivityListResponse> => {
   const query = buildQueryString(params);
   const response = await fetch(`${BASE_URL}/activities${query}`, {
-    next: nextOptions ?? { revalidate: 60, tags: ["activities"] },
+    next: nextOptions ?? { revalidate: 60, tags: [ACTIVITY_CACHE_TAGS.LIST] },
   });
 
   if (!response.ok) {

--- a/src/app/(public)/(main)/page.tsx
+++ b/src/app/(public)/(main)/page.tsx
@@ -1,4 +1,5 @@
 import { getActivityList } from "@/apis/activities.api";
+import { ACTIVITY_CACHE_TAGS } from "@/commons/consts/cacheTags";
 import HeroSection from "./_components/HeroSection";
 import BestItemsCarousel from "./_components/BestItemsCarousel";
 import AllActivitiesPreviewSection from "./_components/AllActivitiesPreviewSection";
@@ -13,7 +14,7 @@ export default async function Home() {
       },
       {
         revalidate: 3600,
-        tags: ["best-activities"],
+        tags: [ACTIVITY_CACHE_TAGS.BEST],
       },
     ),
     getActivityList(
@@ -24,7 +25,7 @@ export default async function Home() {
       },
       {
         revalidate: 3600,
-        tags: ["latest-activities"],
+        tags: [ACTIVITY_CACHE_TAGS.LATEST],
       },
     ),
   ]);

--- a/src/app/(public)/activities/[id]/_components/ActivityHeader.tsx
+++ b/src/app/(public)/activities/[id]/_components/ActivityHeader.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@/commons/contexts/AuthContext";
 import { useRequireAuth } from "@/commons/hooks/useRequireAuth";
 import { deleteMyActivity } from "@/apis/myActivities.api";
 import { handleApiError } from "@/commons/utils/handleApiError";
+import { revalidateActivityListCache } from "@/actions/activities.action";
 
 interface ActivityHeaderProps {
   activity: Activity;
@@ -24,8 +25,14 @@ export function ActivityHeader({ activity }: ActivityHeaderProps) {
 
   const { mutate: deleteActivity } = useMutation({
     mutationFn: () => deleteMyActivity(activity.id),
-    onSuccess: () =>
-      showDialog({ type: "alert", content: "삭제가 완료됐습니다." }),
+    onSuccess: async () => {
+      await revalidateActivityListCache();
+      showDialog({
+        type: "alert",
+        content: "삭제가 완료됐습니다.",
+        onConfirm: () => router.push("/"),
+      });
+    },
     onError: (error) =>
       showDialog({ type: "alert", content: handleApiError(error) }),
   });

--- a/src/commons/consts/cacheTags.ts
+++ b/src/commons/consts/cacheTags.ts
@@ -1,0 +1,5 @@
+export const ACTIVITY_CACHE_TAGS = {
+  BEST: "best-activities",
+  LATEST: "latest-activities",
+  LIST: "activities",
+} as const;


### PR DESCRIPTION
## ✏️ 작업 내용

**변경 파일**
- `src/actions/activities.action.ts` (신규)
- `src/commons/consts/cacheTags.ts` (신규)
- `src/apis/activities.api.ts`
- `src/app/(public)/(main)/page.tsx`
- `src/app/(public)/activities/[id]/_components/ActivityHeader.tsx`

**작업 내용**
- `/activities/[id]` 케밥 메뉴에서 체험 삭제 시 Data Cache를 즉시 무효화하고 메인페이지(`/`)로 리다이렉트
- Server Action(`revalidateActivityListCache`)을 통해 `best-activities`, `latest-activities`, `activities` 태그 purge
- 캐시 태그 문자열을 `ACTIVITY_CACHE_TAGS` 상수로 추출해 분산된 리터럴 관리
- `@base-ui/react` 패키지 미설치 누락 수정

## 🗨️ 논의 사항 (참고 사항)

루트 레이아웃의 `cookies()` 호출로 Full Route Cache는 이미 동적 렌더링되고 있으나, fetch 레벨 Data Cache는 별도로 살아있어 삭제 후 최대 1시간(메인) / 60초(목록)까지 삭제된 체험이 잔존할 수 있었음.

Closes #201