### PR TITLE
refactor: Dialog createPortal 적용 (#226)

### DIFF
--- a/src/components/ui/Dialog/context.tsx
+++ b/src/components/ui/Dialog/context.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   ReactNode,
 } from "react";
-import { flushSync } from "react-dom";
+import { flushSync, createPortal } from "react-dom";
 import { AlertDialog } from "./variants/AlertDialog";
 import { ConfirmDialog } from "./variants/ConfirmDialog";
 
@@ -65,19 +65,26 @@ export function DialogProvider({ children }: { children: ReactNode }) {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [dialog, onClose]);
 
+  function renderDialog(): ReactNode {
+    if (!dialog) return null;
+    if (dialog.type === "alert") {
+      return <AlertDialog content={dialog.content} onClose={handleConfirm} />;
+    }
+    return (
+      <ConfirmDialog
+        content={dialog.content}
+        onClose={handleCancel}
+        onConfirm={handleConfirm}
+      />
+    );
+  }
+
+  const dialogElement = renderDialog();
+
   return (
     <DialogContext.Provider value={{ showDialog, onClose }}>
       <div inert={dialog ? true : undefined}>{children}</div>
-      {dialog?.type === "alert" && (
-        <AlertDialog content={dialog.content} onClose={handleConfirm} />
-      )}
-      {dialog?.type === "confirm" && (
-        <ConfirmDialog
-          content={dialog.content}
-          onClose={handleCancel}
-          onConfirm={handleConfirm}
-        />
-      )}
+      {dialogElement && createPortal(dialogElement, document.body)}
     </DialogContext.Provider>
   );
 }


### PR DESCRIPTION
## 관련 이슈

close #226

## 개요

`DialogProvider`에서 Alert/Confirm Dialog를 JSX 트리에 직접 렌더하던 방식을 `createPortal`로 `document.body`에 마운트하도록 변경합니다.

## 변경 사항

### 변경 전

```tsx
<DialogContext.Provider value={{ showDialog, onClose }}>
  <div inert={dialog ? true : undefined}>{children}</div>
  {dialog?.type === "alert" && (
    <AlertDialog content={dialog.content} onClose={handleConfirm} />
  )}
  {dialog?.type === "confirm" && (
    <ConfirmDialog ... />
  )}
</DialogContext.Provider>
```

### 변경 후

```tsx
function renderDialog(): ReactNode {
  if (!dialog) return null;
  if (dialog.type === "alert") {
    return <AlertDialog content={dialog.content} onClose={handleConfirm} />;
  }
  return <ConfirmDialog ... />;
}

<DialogContext.Provider value={{ showDialog, onClose }}>
  <div inert={dialog ? true : undefined}>{children}</div>
  {dialogElement && createPortal(dialogElement, document.body)}
</DialogContext.Provider>
```

## 효과

- 부모 요소의 `overflow: hidden`, `transform`, `filter` 영향 차단
- Modal과 동일한 Portal 방식으로 통일

## 테스트

- `npx tsc --noEmit` 통과 확인