### PR TITLE
feat: Dialog 포커스 트랩(useFocusTrap) 훅 적용 및 a11y 강화

### DIFF
--- a/src/commons/hooks/useFocusTrap.ts
+++ b/src/commons/hooks/useFocusTrap.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+const FOCUSABLE_SELECTORS = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const nodes = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+  return Array.from(nodes).filter(
+    (el) =>
+      !el.hasAttribute("hidden") &&
+      el.getAttribute("aria-hidden") !== "true",
+  );
+}
+
+export function useFocusTrap<T extends HTMLElement>(
+  isActive: boolean,
+): RefObject<T | null> {
+  const panelRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const trigger = document.activeElement as HTMLElement | null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const initialFocusables = getFocusableElements(panel);
+    (initialFocusables[0] ?? panel).focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+
+      const focusables = getFocusableElements(panel);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+        return;
+      }
+
+      if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      trigger?.focus();
+    };
+  }, [isActive]);
+
+  return panelRef;
+}

--- a/src/components/ui/Dialog/context.tsx
+++ b/src/components/ui/Dialog/context.tsx
@@ -5,10 +5,9 @@ import {
   useState,
   useCallback,
   useEffect,
-  useRef,
   ReactNode,
 } from "react";
-import { flushSync, createPortal } from "react-dom";
+import { createPortal } from "react-dom";
 import { AlertDialog } from "./variants/AlertDialog";
 import { ConfirmDialog } from "./variants/ConfirmDialog";
 
@@ -28,17 +27,13 @@ const DialogContext = createContext<DialogContextValue | null>(null);
 
 export function DialogProvider({ children }: { children: ReactNode }) {
   const [dialog, setDialog] = useState<DialogOptions | null>(null);
-  const triggerRef = useRef<HTMLElement | null>(null);
 
   const showDialog = useCallback((options: DialogOptions) => {
-    triggerRef.current = document.activeElement as HTMLElement;
     setDialog(options);
   }, []);
 
   const onClose = useCallback(() => {
-    // flushSync로 inert 제거를 DOM에 즉시 반영한 뒤 포커스 복원
-    flushSync(() => setDialog(null));
-    triggerRef.current?.focus();
+    setDialog(null);
   }, []);
 
   const handleConfirm = useCallback(() => {

--- a/src/components/ui/Dialog/ui.tsx
+++ b/src/components/ui/Dialog/ui.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { cn } from "@/commons/utils/cn";
 import { useId, ReactNode } from "react";
+import { useFocusTrap } from "@/commons/hooks/useFocusTrap";
 
 interface DialogRendererProps {
   icon?: ReactNode;
@@ -16,6 +17,7 @@ export function DialogRenderer({
   containerClass,
 }: DialogRendererProps) {
   const contentId = useId();
+  const panelRef = useFocusTrap<HTMLDivElement>(true);
 
   return (
     <div
@@ -25,8 +27,10 @@ export function DialogRenderer({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     >
       <div
+        ref={panelRef}
+        tabIndex={-1}
         className={cn(
-          "flex w-[320px] md:w-[400px] flex-col items-center rounded-4xl bg-white py-6 md:py-8",
+          "flex w-[320px] md:w-[400px] flex-col items-center rounded-4xl bg-white py-6 md:py-8 focus:outline-none",
           containerClass,
         )}
       >

--- a/src/components/ui/Modal/context.tsx
+++ b/src/components/ui/Modal/context.tsx
@@ -38,11 +38,9 @@ export function ModalProvider({ children }: { children: ReactNode }) {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", onKeyDown);
-    document.body.style.overflow = "hidden";
 
     return () => {
       document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = "";
     };
   }, [onClose, modal]);
 

--- a/src/components/ui/Modal/ui.tsx
+++ b/src/components/ui/Modal/ui.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ReactNode } from "react";
+import { ReactNode, useId } from "react";
 import { createPortal } from "react-dom";
 import { useFocusTrap } from "@/commons/hooks/useFocusTrap";
 
@@ -10,11 +10,13 @@ interface ModalRendererProps {
 
 export function ModalRenderer({ content, onClose }: ModalRendererProps) {
   const panelRef = useFocusTrap<HTMLDivElement>(true);
+  const contentId = useId();
 
   return createPortal(
     <div
       role="dialog"
       aria-modal="true"
+      aria-labelledby={contentId}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
@@ -33,7 +35,7 @@ export function ModalRenderer({ content, onClose }: ModalRendererProps) {
           </button>
         </div>
 
-        {content}
+        <div id={contentId}>{content}</div>
       </div>
     </div>,
     document.body,

--- a/src/components/ui/Modal/ui.tsx
+++ b/src/components/ui/Modal/ui.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/commons/hooks/useFocusTrap";
 
 interface ModalRendererProps {
   content: ReactNode;
@@ -8,6 +9,8 @@ interface ModalRendererProps {
 }
 
 export function ModalRenderer({ content, onClose }: ModalRendererProps) {
+  const panelRef = useFocusTrap<HTMLDivElement>(true);
+
   return createPortal(
     <div
       role="dialog"
@@ -15,10 +18,13 @@ export function ModalRenderer({ content, onClose }: ModalRendererProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="scrollbar-ghost relative max-h-[85vh] overflow-y-auto rounded-3xl bg-white px-6 md:px-7 pt-5 pb-7 md:pb-11">
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        className="scrollbar-ghost relative max-h-[85vh] overflow-y-auto rounded-3xl bg-white px-6 md:px-7 pt-5 pb-7 md:pb-11 focus:outline-none"
+      >
         <div className="flex items-center justify-end mb-1">
           <button
-            autoFocus
             onClick={onClose}
             aria-label="닫기"
             className="cursor-pointer text-xs font-bold text-gray-600 hover:text-black"

--- a/src/components/ui/Modal/ui.tsx
+++ b/src/components/ui/Modal/ui.tsx
@@ -29,7 +29,7 @@ export function ModalRenderer({ content, onClose }: ModalRendererProps) {
           <button
             onClick={onClose}
             aria-label="닫기"
-            className="cursor-pointer text-xs font-bold text-gray-600 hover:text-black"
+            className="cursor-pointer rounded text-xs font-bold text-gray-600 outline-none hover:text-black focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2"
           >
             ✕
           </button>


### PR DESCRIPTION
## ✏️ 작업 내용

WAI-ARIA 모달 다이얼로그 가이드라인에 따라 **Tab 포커스 트랩**을 추가하고, Dialog에 흩어져 있던 포커스 관리 로직을 재사용 가능한 `useFocusTrap` 훅으로 추출했습니다.

### `src/commons/hooks/useFocusTrap.ts` (신규)

- 오픈 시 `document.activeElement` 를 자동 저장 → 언마운트 시 해당 요소로 포커스 복원
- Tab / Shift+Tab 키를 가로채 첫·마지막 포커스 가능 요소 간 **순환 트랩**
- `disabled` / `hidden` / `aria-hidden="true"` 요소 필터링
- 포커스 가능한 요소가 없으면 패널(`tabIndex={-1}`)로 폴백 포커스
- body scroll lock (오픈 중 배경 스크롤 방지)

### `src/components/ui/Dialog/ui.tsx`

- `DialogRenderer` 패널에 `ref={panelRef}` + `tabIndex={-1}` + `focus:outline-none` 부여
- `useFocusTrap<HTMLDivElement>(true)` 호출

### `src/components/ui/Dialog/context.tsx`

- `triggerRef` / `flushSync` 기반 포커스 복원 로직 제거 (훅으로 이관)
- ESC 종료 / `inert` / `createPortal` 등 기존 a11y 동작은 그대로 유지

## 🗨️ 논의 사항 (참고 사항)

### 기대 효과
키보드 사용자가 Dialog가 열린 상태에서 Tab을 눌러도 포커스가 패널 바깥(inert 처리된 배경)으로 벗어나지 않습니다. `inert` + `useFocusTrap` 조합으로 키보드·마우스·스크린리더 모두에 대해 모달 격리를 달성합니다.

### 호환성 / 회귀 확인 포인트
- AlertDialog "확인" 버튼 → 동작 유지
- ConfirmDialog "네" / "아니오" 버튼 → 동작 유지
- ESC → 기존과 동일하게 onCancel 실행 후 닫힘
- Dialog 닫힌 뒤 원래 트리거(버튼 등)로 포커스 복원 확인 필요

Closes #228
